### PR TITLE
Examples party and fair dice

### DIFF
--- a/chapters/examples.typ
+++ b/chapters/examples.typ
@@ -81,17 +81,47 @@ $P("nicht erwischt werden") = (10-n)/10 (8+n)/15$ soll maximiert werden. $-->$ n
 
 Es wird gewürfelt bis eine 6 geworfen wird. $X$ sei die Anzahl der Versuche bis zum Erfolg. Gesucht ist der Erwartungswert von $X$.
 
-$ P(X = x_1 = 1) = 1 / 6 $
+$ P(X = x_1 = 1) &= 1 / 6 \
+  P(X = x_2 = 2) &= 5 / 6 dot 1 / 6 \
+  P(X = x_k = k) &= (5 / 6)^(k - 1) dot 1 / 6 $
 
-$ P(X = x_2 = 2) = 5 / 6 dot 1 / 6 $
+$ E(X) = sum_(k = 1)^oo x_i p_i = sum_(k = 1)^oo k P(X = k) = sum_(k = 1)^oo k dot (5 / 6)^(k - 1) dot 1 / 6 $
 
-$ P(X = x_k = k) = (5 / 6)^(k - 1) dot 1 / 6 $
+$ sum_(k = 0)^oo q^k = 1 / (1 - q) ==>^(d / (d q)) sum_(k = 0)^oo k q^(k - 1) = 1 / (1 - q)^2 $
 
-$ E(X) = sum_(k=1)^oo x_i p_i = sum_(k=1)^oo k P(X = k) = sum_(k=1)^oo k dot (5 / 6)^(k-1) dot 1 / 6 $
+$ E(X) = 1 / 6 dot sum_(k = 1)^oo k dot (5 / 6)^(k - 1) = 1 / 6 dot 1 / (1 - 5 / 6)^2 = 6 $
 
-$ sum_(k=0)^oo q^k = 1 / (1 - q) | d / (d x) $
+== Anstoßen auf einem Fest
 
-$ ==> sum_(k=0)^oo k q^(k - 1) = 1 / (1 - q)^2 $
+Die Anzahl der "Kling" wird gezählt. A sagt $>500$, B sagt $<550$.
+Wie viele Gäste sind auf der Party unter der Annahme, dass jeder mit jedem anderen anstößt?
 
-$ E(X) = 1 / 6 dot sum_(k=1)^oo k dot (5 / 6)^(k-1) = 1 / 6 dot 1 / (1 - 5 / 6)^2 = 6 $
+$ 500 <= X <= 550 $
 
+$n$ sei die Anzahl der Gäste.
+
+=== Ansatz A: über Summe
+
+#h(1fr) $sum_(k = 1)^n k = (n (n + 1)) / 2$ #h(1fr) $X = sum_(k = 1)^(n - 1) k = ((n - 1) n) / 2$ #h(1fr)
+
+$ 500 <=^! ((n - 1) n) / 2 <=> 0 <=^! n^2 - n - 1000 <=> n >= 32.1 $
+
+$ 550 >=^! ((n - 1) n) / 2 <=> 0 >=^! n^2 - n - 1100 <=> n <= 33.7 $
+
+$ 32.1 <= n <= 33.7 and n in NN => n = 33 $
+
+Es sind 33 Gäste auf der Party.
+
+Probe:
+
+$ X = sum_(k = 1)^(33 - 1) = 528 => 500 <= X <= 550 $
+
+=== Ansatz B: über Binomialkoeffizienten
+
+$ 500 <= binom(n, 2) = n! / (2! (n - 2)!) = (n (n - 1)) / 2 <= 550 $
+
+Danach quadratische Gleichungen lösen wie in Ansatz A.
+
+Probe:
+
+$ X = binom(33, 2) = 528 => 500 <= X <= 550 $

--- a/chapters/examples.typ
+++ b/chapters/examples.typ
@@ -75,4 +75,23 @@ B: 7-n-mal Sand, 15-(7-n) = 8+n Brause
 
 $P("nicht erwischt werden") = (10-n)/10 (8+n)/15$ soll maximiert werden. $-->$ nach $n$ umstellen
 
+== Anstoßen auf Party
+
+== Würfeln bis 6 geworfen wird
+
+Es wird gewürfelt bis eine 6 geworfen wird. $X$ sei die Anzahl der Versuche bis zum Erfolg. Gesucht ist der Erwartungswert von $X$.
+
+$ P(X = x_1 = 1) = 1 / 6 $
+
+$ P(X = x_2 = 2) = 5 / 6 dot 1 / 6 $
+
+$ P(X = x_k = k) = (5 / 6)^(k - 1) dot 1 / 6 $
+
+$ E(X) = sum_(k=1)^oo x_i p_i = sum_(k=1)^oo k P(X = k) = sum_(k=1)^oo k dot (5 / 6)^(k-1) dot 1 / 6 $
+
+$ sum_(k=0)^oo q^k = 1 / (1 - q) | d / (d x) $
+
+$ ==> sum_(k=0)^oo k q^(k - 1) = 1 / (1 - q)^2 $
+
+$ E(X) = 1 / 6 dot sum_(k=1)^oo k dot (5 / 6)^(k-1) = 1 / 6 dot 1 / (1 - 5 / 6)^2 = 6 $
 


### PR DESCRIPTION
Beispiele hinzugefügt:
* Berechnung des Erwartungswertes der Anzahl der Würfe beim Würfeln bis eine 6 geworfen wird.
* Aufgabe zur Berechnung der Partygäste anhand der Anzahl zusammenstoßender Gläser beim Anstoßen.